### PR TITLE
Fix bug causing limbo on client side validation fail

### DIFF
--- a/app/qcl/templates/add.html.j2
+++ b/app/qcl/templates/add.html.j2
@@ -26,7 +26,7 @@
     <p class="error-message">{{ error }}</p>
 </div>
 {% endif %}
-<form id="form" method="POST" action="/add">
+<form id="form" method="POST" action="/add" novalidate>
     <div class="container border border-primary rounded">
         {{ form.csrf_token }}
         <label for="editor_box" class="form-label">Source Code</label>

--- a/app/qcl/templates/classify.html.j2
+++ b/app/qcl/templates/classify.html.j2
@@ -26,7 +26,7 @@
     <p class="error-message">{{ error }}</p>
 </div>
 {% endif %}
-<form id="form" method="POST" action="/classify">
+<form id="form" method="POST" action="/classify" novalidate>
     {{ form.csrf_token }}
     <div class="form-floating mb-3">
         {{ form.name }}

--- a/app/qcl/templates/doc.html.j2
+++ b/app/qcl/templates/doc.html.j2
@@ -29,7 +29,7 @@
     <p class="error-message">{{ error }}</p>
 </div>
 {% endif %}
-<form id="form" method="POST" action="/doc">
+<form id="form" method="POST" action="/doc" novalidate>
     <div class="container border border-primary rounded">
         {{ form.csrf_token }}
         <label for="editor_box_code" class="form-label">Source Code</label>

--- a/app/qcl/templates/test.html.j2
+++ b/app/qcl/templates/test.html.j2
@@ -30,7 +30,7 @@
     <p class="error-message">{{ error }}</p>
 </div>
 {% endif %}
-<form id="form" method="POST" action="/test">
+<form id="form" method="POST" action="/test" novalidate>
     <div class="container border border-primary rounded">
         {{ form.csrf_token }}
         <label for="editor_box_documented" class="form-label">Source Code (Documented)</label>


### PR DESCRIPTION
App would go into a sort of limbo state, if client side form validation would fail on new-function workflow. In that case the button was already replaced with a spinner, but a page reload would not occur, leaving the original button inaccessible.

Fixed by disabling client side validation in those cases. Effect on security and user experience is minimal, as server-side validation does the job fast enough.